### PR TITLE
feat: Add event color support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -518,7 +518,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 function getKeysFilePath(): string {
-  return '/Users/kirniy/google-calendar-mcp/gcp-oauth.keys.json';
+  const relativePath = path.join(
+    path.dirname(new URL(import.meta.url).pathname),
+    '../gcp-oauth.keys.json'
+  );
+  const absolutePath = path.resolve(relativePath);
+  return absolutePath;
 }
 
 // Start the server

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { ListToolsRequestSchema, CallToolRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { google } from 'googleapis';
 import { OAuth2Client } from 'google-auth-library';
-import * as fs from 'fs/promises';
-import * as path from 'path';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { z } from "zod";
 import { AuthServer } from './auth-server.js';
 import { TokenManager } from './token-manager.js';
@@ -21,11 +21,24 @@ interface CalendarEvent {
   end?: { dateTime?: string | null; date?: string | null; };
   location?: string | null;
   attendees?: CalendarEventAttendee[] | null;
+  colorId?: string | null;
 }
 
 interface CalendarEventAttendee {
   email?: string | null;
   responseStatus?: string | null;
+}
+
+interface ColorDefinition {
+  background: string;
+  foreground: string;
+}
+
+interface Colors {
+  kind: "calendar#colors";
+  updated: string;
+  calendar: { [key: string]: ColorDefinition };
+  event: { [key: string]: ColorDefinition };
 }
 
 // Define Zod schemas for validation
@@ -45,6 +58,7 @@ const CreateEventArgumentsSchema = z.object({
     email: z.string()
   })).optional(),
   location: z.string().optional(),
+  colorId: z.string().optional().describe("The color ID for the event, e.g., '1' for Lavender, '2' for Sage, etc."),
 });
 
 const UpdateEventArgumentsSchema = z.object({
@@ -58,6 +72,7 @@ const UpdateEventArgumentsSchema = z.object({
     email: z.string()
   })).optional(),
   location: z.string().optional(),
+  colorId: z.string().optional().describe("The color ID for the event, e.g., '1' for Lavender, '2' for Sage, etc."),
 });
 
 const DeleteEventArgumentsSchema = z.object({
@@ -247,6 +262,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 },
                 required: ["email"]
               }
+            },
+            colorId: {
+              type: "string",
+              description: "The color ID for the event (e.g., '1' for Lavender). Use list-colors to see available colors."
             }
           },
           required: ["calendarId", "summary", "start", "end"],
@@ -299,6 +318,10 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
                 },
                 required: ["email"]
               }
+            },
+            colorId: {
+              type: "string",
+              description: "The color ID for the event (e.g., '1' for Lavender). Use list-colors to see available colors."
             }
           },
           required: ["calendarId", "eventId"],
@@ -320,6 +343,15 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
             },
           },
           required: ["calendarId", "eventId"],
+        },
+      },
+      {
+        name: "list-colors",
+        description: "List available colors for both calendars and events",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
         },
       },
     ],
@@ -374,7 +406,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     `${a.email || 'no-email'} (${a.responseStatus || 'unknown'})`).join(', ')}`
                 : '';
               const locationInfo = event.location ? `\nLocation: ${event.location}` : '';
-              return `${event.summary || 'Untitled'} (${event.id || 'no-id'})${locationInfo}\nStart: ${event.start?.dateTime || event.start?.date || 'unspecified'}\nEnd: ${event.end?.dateTime || event.end?.date || 'unspecified'}${attendeeList}\n`;
+              const colorInfo = event.colorId ? `\nColor: ${event.colorId}` : '';
+              return `${event.summary || 'Untitled'} (${event.id || 'no-id'})${locationInfo}${colorInfo}\nStart: ${event.start?.dateTime || event.start?.date || 'unspecified'}\nEnd: ${event.end?.dateTime || event.end?.date || 'unspecified'}${attendeeList}\n`;
             }).join('\n')
           }]
         };
@@ -391,6 +424,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             end: { dateTime: validArgs.end },
             attendees: validArgs.attendees,
             location: validArgs.location,
+            colorId: validArgs.colorId,
           },
         }).then(response => response.data);
         
@@ -414,6 +448,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             end: validArgs.end ? { dateTime: validArgs.end } : undefined,
             attendees: validArgs.attendees,
             location: validArgs.location,
+            colorId: validArgs.colorId,
           },
         }).then(response => response.data);
         
@@ -435,7 +470,40 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         return {
           content: [{
             type: "text",
-            text: `Event deleted successfully`
+            text: 'Event deleted successfully'
+          }]
+        };
+      }
+
+      case "list-colors": {
+        const response = await calendar.colors.get();
+        const colors = response.data as Colors;
+        
+        // Verify the response matches expected format
+        if (colors.kind !== "calendar#colors") {
+          throw new Error("Invalid color data received from Google Calendar API");
+        }
+
+        const formatColorSection = (title: string, colors: { [key: string]: ColorDefinition }) => {
+          if (!colors || Object.keys(colors).length === 0) {
+            return `${title}:\n  No colors available`;
+          }
+          return `${title}:\n${Object.entries(colors)
+            .map(([id, color]) => 
+              `  ID: ${id}\n    Background: ${color.background}\n    Foreground: ${color.foreground}`
+            ).join('\n')}`;
+        };
+
+        const sections = [
+          `Last Updated: ${new Date(colors.updated).toISOString()}`, // Use ISO format for RFC3339
+          formatColorSection('Calendar Colors', colors.calendar),
+          formatColorSection('Event Colors', colors.event)
+        ];
+
+        return {
+          content: [{
+            type: "text",
+            text: sections.join('\n\n')
           }]
         };
       }
@@ -450,12 +518,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 function getKeysFilePath(): string {
-  const relativePath = path.join(
-    path.dirname(new URL(import.meta.url).pathname),
-    '../gcp-oauth.keys.json'
-  );
-  const absolutePath = path.resolve(relativePath);
-  return absolutePath;
+  return '/Users/kirniy/google-calendar-mcp/gcp-oauth.keys.json';
 }
 
 // Start the server


### PR DESCRIPTION
This PR adds support for Google Calendar event colors by: - Adding `colorId` field to the `CalendarEvent` interface - Enabling color information to be retrieved from the Google Calendar API - Allowing events to display their associated colors in listings. It also allows the MCP to edit and set colors for individual events in Google Calendar. 